### PR TITLE
Don’t decode entities in script tags

### DIFF
--- a/src/handlers/Handler.js
+++ b/src/handlers/Handler.js
@@ -66,7 +66,9 @@ export default class Handler {
       return;
     }
 
-    text = entities.decodeHTML(text);
+    if (name !== 'script') {
+      text = entities.decodeHTML(text);
+    }
 
     if (typeof this[name] === 'function') {
       this[name](attributes, text);

--- a/src/handlers/JSONLD.js
+++ b/src/handlers/JSONLD.js
@@ -1,19 +1,37 @@
 import Handler from './Handler';
 import {add} from '../utils';
+import entities from 'entities';
 
 export default class JSONLD extends Handler {
   constructor() {
     super();
-    
+
     this.result = null;
   }
-  
+
   script(attributes, text) {
     if (attributes.type === 'application/ld+json') {
       try {
-        let content = JSON.parse(text);
+        let content = decodeEntities(JSON.parse(text));
         add(this, 'result', content);
       } catch (err) {};
     }
   }
+}
+
+function decodeEntities(obj) {
+  if (typeof obj === 'string') {
+    return entities.decodeHTML(obj);
+  } else if (Array.isArray(obj)) {
+    return obj.map(decodeEntities);
+  } else if (obj && typeof obj === 'object') {
+    let res = {};
+    for (let key in obj) {
+      res[key] = decodeEntities(obj[key]);
+    }
+
+    return res;
+  }
+
+  return obj;
 }


### PR DESCRIPTION
It was causing JSON parsing to fail because quote entities were being decoded prior to JSON.parse. Disabled default entity decoding for script tags, and did it on the parsed JSON instead.